### PR TITLE
Add missing dll

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.156" />
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="PolySharp" Version="1.14.1" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.2.0" />
     <PackageVersion Include="Verify.Xunit" Version="25.0.2" />
     <PackageVersion Include="xunit" Version="2.8.1" />

--- a/src/SafeRouting.Generator/GeneratorDependencyResolver.props
+++ b/src/SafeRouting.Generator/GeneratorDependencyResolver.props
@@ -1,0 +1,108 @@
+<Project>
+
+  <PropertyGroup>
+    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);AddGenerationTimeReferences</GetTargetPathDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_SystemLibs Include="Microsoft.Bcl.AsyncInterfaces" />
+    <_SystemLibs Include="Microsoft.CodeAnalysis" />
+    <_SystemLibs Include="Microsoft.CodeAnalysis.CSharp" />
+    <_SystemLibs Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <_SystemLibs Include="Microsoft.CodeAnalysis.Workspaces" />
+    <_SystemLibs Include="System.Buffers" />
+    <_SystemLibs Include="System.Collections.Immutable" />
+    <_SystemLibs Include="System.Composition.AttributedModel" />
+    <_SystemLibs Include="System.Composition.Convention" />
+    <_SystemLibs Include="System.Composition.Hosting" />
+    <_SystemLibs Include="System.Composition.Runtime" />
+    <_SystemLibs Include="System.Composition.TypedParts" />
+    <_SystemLibs Include="System.IO.Pipelines" />
+    <_SystemLibs Include="System.Memory" />
+    <_SystemLibs Include="System.Numerics.Vectors" />
+    <_SystemLibs Include="System.Reflection.Metadata" />
+    <_SystemLibs Include="System.Runtime.CompilerServices.Unsafe" />
+    <_SystemLibs Include="System.Text.Encoding.CodePages" />
+    <_SystemLibs Include="System.Threading.Tasks.Extensions" />
+
+    <_SystemLibs Include="Microsoft.NETCore.Platforms" />
+    <_SystemLibs Include="Microsoft.Win32.Primitives" />
+    <_SystemLibs Include="System.AppContext" />
+    <_SystemLibs Include="System.Collections" />
+    <_SystemLibs Include="System.Collections.Concurrent" />
+    <_SystemLibs Include="System.Console" />
+    <_SystemLibs Include="System.Diagnostics.Debug" />
+    <_SystemLibs Include="System.Diagnostics.Tools" />
+    <_SystemLibs Include="System.Diagnostics.Tracing" />
+    <_SystemLibs Include="System.Globalization" />
+    <_SystemLibs Include="System.Globalization.Calendars" />
+    <_SystemLibs Include="System.IO" />
+    <_SystemLibs Include="System.IO.Compression" />
+    <_SystemLibs Include="System.IO.Compression.ZipFile" />
+    <_SystemLibs Include="System.IO.FileSystem" />
+    <_SystemLibs Include="System.IO.FileSystem.Primitives" />
+    <_SystemLibs Include="System.Linq" />
+    <_SystemLibs Include="System.Linq.Expressions" />
+    <_SystemLibs Include="System.Net.Http" />
+    <_SystemLibs Include="System.Net.Primitives" />
+    <_SystemLibs Include="System.Net.Sockets" />
+    <_SystemLibs Include="System.ObjectModel" />
+    <_SystemLibs Include="System.Reflection" />
+    <_SystemLibs Include="System.Reflection.Extensions" />
+    <_SystemLibs Include="System.Reflection.Primitives" />
+    <_SystemLibs Include="System.Resources.ResourceManager" />
+    <_SystemLibs Include="System.Runtime" />
+    <_SystemLibs Include="System.Runtime.Extensions" />
+    <_SystemLibs Include="System.Runtime.Handles" />
+    <_SystemLibs Include="System.Runtime.InteropServices" />
+    <_SystemLibs Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <_SystemLibs Include="System.Runtime.Numerics" />
+    <_SystemLibs Include="System.Security.Cryptography.Algorithms" />
+    <_SystemLibs Include="System.Security.Cryptography.Encoding" />
+    <_SystemLibs Include="System.Security.Cryptography.Primitives" />
+    <_SystemLibs Include="System.Security.Cryptography.X509Certificates" />
+    <_SystemLibs Include="System.Text.Encoding" />
+    <_SystemLibs Include="System.Text.Encoding.Extensions" />
+    <_SystemLibs Include="System.Text.RegularExpressions" />
+    <_SystemLibs Include="System.Threading" />
+    <_SystemLibs Include="System.Threading.Tasks" />
+    <_SystemLibs Include="System.Threading.Timer" />
+    <_SystemLibs Include="System.Xml.ReaderWriter" />
+    <_SystemLibs Include="System.Xml.XDocument" />
+
+    <!-- Fix for Reference assemblies should not be loaded for execution.  They can only be loaded in the Reflection-only loader context. (0x80131058)) -->
+    <_SystemLibs Include="System.Dynamic.Runtime" />
+
+    <!-- https://github.com/HavenDV/H.Generators.Extensions/issues/3 -->
+    <_SystemLibs Include="Microsoft.CSharp" />
+    <_SystemLibs Include="System.Runtime.Serialization.Primitives" />
+
+    <!-- https://discord.com/channels/988253265550532680/988253266393579583/1075854799821623346 -->
+    <_SystemLibs Include="System.ComponentModel" />
+    <_SystemLibs Include="System.Runtime.Serialization.Formatters" />
+  </ItemGroup>
+
+  <!--
+    https://github.com/dotnet/roslyn/issues/52017#issuecomment-1046216200
+    This automatically adds explicit and transient dependencies so that they are available at the time the generator is executed.
+  -->
+  <Target Name="AddGenerationTimeReferences" DependsOnTargets="ResolveReferences">
+    <PropertyGroup>
+      <_SystemLibsProperty>@(_SystemLibs)</_SystemLibsProperty>
+      <_ResolvedCompileFileDefinitions>@(ResolvedCompileFileDefinitions)</_ResolvedCompileFileDefinitions>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ResolvedCompileFileDefinitionsWithoutSystem Include="%(ResolvedCompileFileDefinitions.Identity)" Condition="$(_SystemLibsProperty) != '' AND $(_ResolvedCompileFileDefinitions) != '' AND !$(_SystemLibsProperty.Contains(%(ResolvedCompileFileDefinitions.Filename)))" />
+      <ResolvedCompileFileDefinitionsWithoutSystemNonRef Include="@(ResolvedCompileFileDefinitionsWithoutSystem->Replace('\ref\', '\lib\')->Replace('/ref/', '/lib/'))" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="@(ResolvedCompileFileDefinitionsWithoutSystemNonRef)" Pack="true" PackagePath="analyzers/dotnet/cs" />
+      <TargetPathWithTargetPlatformMoniker Include="@(ResolvedCompileFileDefinitionsWithoutSystemNonRef)" IncludeRuntimeDependency="false" />
+    </ItemGroup>
+
+    <Message Text="Added generation time reference: %(ResolvedCompileFileDefinitionsWithoutSystemNonRef.Identity)" Importance="high" Condition="$(_ResolvedCompileFileDefinitions) != ''"/>
+  </Target>
+
+</Project>

--- a/src/SafeRouting.Generator/SafeRouting.Generator.csproj
+++ b/src/SafeRouting.Generator/SafeRouting.Generator.csproj
@@ -21,13 +21,12 @@
     <None Include="$(OutputPath)\SafeRouting.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\SafeRouting.Common.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true" />
     <None Include="$(OutputPath)\SafeRouting.Common.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="true" />
-    <None Include="$(PkgMicrosoft_AspNetCore_Razor)\lib\netstandard2.0\Microsoft.AspNetCore.Razor.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
     <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="\README.md" />
     <None Include="..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="PolySharp">

--- a/src/SafeRouting.Generator/SafeRouting.Generator.csproj
+++ b/src/SafeRouting.Generator/SafeRouting.Generator.csproj
@@ -14,6 +14,8 @@
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
+  <Import Project="GeneratorDependencyResolver.props" />
+
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\SafeRouting.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />

--- a/src/SafeRouting.Generator/SafeRouting.Generator.csproj
+++ b/src/SafeRouting.Generator/SafeRouting.Generator.csproj
@@ -19,11 +19,13 @@
     <None Include="$(OutputPath)\SafeRouting.Common.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\SafeRouting.Common.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true" />
     <None Include="$(OutputPath)\SafeRouting.Common.xml" Pack="true" PackagePath="lib\netstandard2.0" Visible="true" />
+    <None Include="$(PkgMicrosoft_AspNetCore_Razor)\lib\netstandard2.0\Microsoft.AspNetCore.Razor.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
     <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="\README.md" />
     <None Include="..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Razor" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="PolySharp">

--- a/src/SafeRouting.Generator/SafeRouting.Generator.csproj
+++ b/src/SafeRouting.Generator/SafeRouting.Generator.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Encodings.Web" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="PolySharp">


### PR DESCRIPTION
Hi, when using this source generator, Rider complains that it could not resolve Razor dependency.

![SafeRouting-Razor](https://github.com/user-attachments/assets/271cbc1b-4488-4cf1-88f9-8f839186f145)

For automated dependency bundling, I used https://github.com/HavenDV/H.Generators.Extensions/blob/main/src/libs/H.Generators.Extensions/build/H.Generators.Extensions.props. It's also possible to use the `H.Generators.Extensions` package directly, but it forces up-to-date dependencies that conflict with dependencies used in this generator.

It's more correct to add the whole Microsoft.AspNetCore.Mvc package, but it causes conflicts with local test projects, and it would increase package size significantly. See:
![Mvc-dependencies](https://github.com/user-attachments/assets/d6db3943-27b2-4671-b595-da96599cde26)

Compared to Razor package:
![Razor-dependencies](https://github.com/user-attachments/assets/93ef0374-52d5-40dd-8151-b4c42ac4c877)

Using only Razor dependencies solves the issue.

